### PR TITLE
Use Italian month names in PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,10 @@
           docPdf.text('Mese - Presenze', 10, y);
           y += 10;
           Object.entries(monthlyCounts).forEach(([month, count]) => {
-            docPdf.text(`${month}: ${count}`, 10, y);
+            const date = new Date(`${month}-01`);
+            const monthName = date.toLocaleString('it-IT', { month: 'long' });
+            const year = date.getFullYear();
+            docPdf.text(`${monthName} ${year}: ${count}`, 10, y);
             y += 10;
           });
           docPdf.save(`${studentName}.pdf`);


### PR DESCRIPTION
## Summary
- Format monthly attendance counts with Italian month names and year in generated PDF

## Testing
- `node <<'NODE'
const monthlyCounts={ '2024-02':3,'2024-03':2 };
Object.entries(monthlyCounts).forEach(([month,count])=>{
  const date=new Date(`${month}-01`);
  const monthName=date.toLocaleString('it-IT',{month:'long'});
  const year=date.getFullYear();
  console.log(`${monthName} ${year}: ${count}`);
});
NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8560a63a8832691715978c6febb2c